### PR TITLE
Recommend w3tc on "Plugins > Add New". Resolves #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ composer require boldgrid/library
 * New feature: Show BoldGrid News widget in the dashboard.
 * New feature: Show BoldGrid Notifications widget in the dashboard.
 
+### 2.9.3 ###
+
+Release date:
+
+* Update: Recommend W3 Total Cache on Plugins > Add New.
+
 ### 2.9.2 ###
 
 Release date: August 1st, 2019

--- a/src/library.global.php
+++ b/src/library.global.php
@@ -79,6 +79,11 @@ return array(
 				'link' => '//wpforms.com/lite-upgrade/',
 				'priority' => 80,
 			),
+			'w3-total-cache' => array(
+				'slug' => 'w3-total-cache',
+				'link' => '//wordpress.org/plugins/w3-total-cache/',
+				'priority' => 80,
+			),
 		),
 	),
 	'api_calls' => array(


### PR DESCRIPTION
Testing:

`delete_option( '_site_transient_boldgrid_wporg_plugins' );` and then go to **Plugins > Add New** and make sure W3TC is listed.