### PR TITLE
Remove staging from recommend plugins. Resolves #28

### DIFF
--- a/src/library.global.php
+++ b/src/library.global.php
@@ -40,11 +40,6 @@ return array(
 				'file' => 'boldgrid-inspirations/boldgrid-inspirations.php',
 				'priority' => 20,
 			),
-			'boldgrid-staging' => array(
-				'key' => 'staging',
-				'file' => 'boldgrid-staging/boldgrid-staging.php',
-				'priority' => 60,
-			),
 			'boldgrid-gallery' => array(
 				'key' => 'gallery-wc-canvas',
 				'file' => 'boldgrid-gallery/wc-gallery.php',


### PR DESCRIPTION
Testing:
`delete_option( '_site_transient_boldgrid_plugins' );` and then make sure staging doesn't show.