### PR TITLE
Remove .notice borders for WP 5.3. Fixes #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ composer require boldgrid/library
 
 ## Changelog ##
 
+### 2.10.5 ###
+
+Release date: November ??, 2019
+
+* Bug fix: Misc style fixes for WordPress 5.3.
+
 ### 2.10.4 ###
 
 Release date: October 11th, 2019

--- a/src/assets/css/admin.css
+++ b/src/assets/css/admin.css
@@ -2,7 +2,8 @@
 .settings_page_boldgrid-connect #container_boldgrid_api_key_notice {
 	background: transparent;
 	box-shadow: none;
-	border-left: 0;
+	/* WordPress 5.3 adds notices to borders. */
+	border: 0;
 	width: auto;
 }
 


### PR DESCRIPTION
Please see #42 