### PR TITLE
add conditional to be sure response propert is set

### DIFF
--- a/src/Library/Theme/Theme.php
+++ b/src/Library/Theme/Theme.php
@@ -138,7 +138,8 @@ class Theme {
 	 * @since 2.12.2
 	 */
 	public function setHasUpdate() {
-		if ( get_site_transient( 'update_themes' ) ) {
+		$transient = get_site_transient( 'update_themes' );
+		if ( $transient && isset( $transient->response ) ) {
 			$transient = get_site_transient( 'update_themes' )->response;
 		} else {
 			$transient = null;


### PR DESCRIPTION
This should resolve #77 by ensuring that the returned transient has the 'response' property set.