### PR TITLE
filter configs based on option

### DIFF
--- a/src/Library/Configs.php
+++ b/src/Library/Configs.php
@@ -87,7 +87,7 @@ class Configs {
 		 *
 		 * Filtering via a actual filter (above) may be difficult due to timing / plugin load order.
 		 */
-		$option_overrides = get_option( 'bg_library_configs', array() );
+		$option_overrides = get_option( 'bglib_configs', array() );
 		$defaults         = wp_parse_args( $option_overrides, $defaults );
 
 		return self::$configs = wp_parse_args( $configs, $defaults );

--- a/src/Library/Configs.php
+++ b/src/Library/Configs.php
@@ -82,6 +82,14 @@ class Configs {
 			}
 		}
 
+		/*
+		 * Allow the default configs to be filtered via an option, bg_library_configs.
+		 *
+		 * Filtering via a actual filter (above) may be difficult due to timing / plugin load order.
+		 */
+		$option_overrides = get_option( 'bg_library_configs', array() );
+		$defaults         = wp_parse_args( $option_overrides, $defaults );
+
 		return self::$configs = wp_parse_args( $configs, $defaults );
 	}
 


### PR DESCRIPTION
Testing instructions:

Put this somewhere to actually set the option:
```
update_option( 'bglib_configs', array(
	'api' => 'https://FILTERED-API.boldgrid.com',
) );
```

Edit this method https://github.com/BoldGrid/library/blob/master/src/Library/Api/Call.php#L158 and add
```
error_log( 'api url = ' . $this->url );
```

Test some API calls... IE force the "enter key" promt to show here https://github.com/BoldGrid/library/blob/master/src/Library/Notice/KeyPrompt.php#L192 Put in a key and try to validate it.